### PR TITLE
Fix stray timing expression in OpenAI call

### DIFF
--- a/lead_recovery/summarizer.py
+++ b/lead_recovery/summarizer.py
@@ -245,7 +245,7 @@ class ConversationSummarizer:
                 except (AttributeError, KeyError) as e:
                     logger.warning(f"Could not extract token usage from response: {e}")
             
-            time.time() - start_time
+            logger.debug("OpenAI request completed in %.2fs", time.time() - start_time)
             
             if not content:
                 logger.error("OpenAI response was empty despite status 'completed'")

--- a/setup_codex.sh
+++ b/setup_codex.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Quick setup script for Codex environments
+# Creates a virtual environment and installs project dependencies.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$PROJECT_DIR"
+
+if [ ! -d "fresh_env" ]; then
+    python3 -m venv fresh_env
+fi
+
+source fresh_env/bin/activate
+
+python -m pip install --upgrade pip
+
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi
+
+if [ -f requirements-dev.txt ]; then
+    pip install -r requirements-dev.txt
+fi
+
+pip install -e .
+
+echo "Environment setup complete. Activate it with 'source fresh_env/bin/activate'."


### PR DESCRIPTION
## Summary
- remove stray expression in `_call_openai`
- log call duration for clarity
- add a simple setup script for Codex environments

## Testing
- `ruff check lead_recovery/summarizer.py`
- `black --check lead_recovery/summarizer.py` *(fails: would reformat)*
- `python -m pytest -k summarizer_helpers -q` *(fails: No module named pytest)*