### PR TITLE
Remove dashboard package from pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,9 +24,9 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-        files: ^(lead_recovery/|dashboard/|tests/)
+        files: ^(lead_recovery/|tests/)
       - id: ruff-format
-        files: ^(lead_recovery/|dashboard/|tests/)
+        files: ^(lead_recovery/|tests/)
 
 - repo: local
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ ignore = ["D100", "D104", "D107", "D203", "D212", "D415"]
 quote-style = "double"
 
 [tool.setuptools]
-packages = ["lead_recovery", "dashboard"]
+packages = ["lead_recovery"]
 
 [tool.setuptools.package-data]
 lead_recovery = ["prompts/openai_prompt.txt", "sql/*.sql"]


### PR DESCRIPTION
## Summary
- remove dashboard from setuptools packages
- narrow ruff pre-commit paths

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pytest -q` *(fails: ImportError during collection)*