### PR TITLE
Remove unused helper functions

### DIFF
--- a/lead_recovery/summarizer_helpers.py
+++ b/lead_recovery/summarizer_helpers.py
@@ -96,20 +96,6 @@ def _attempt_fix_colons_in_values(text: str) -> str:
         return text
 
 
-def _attempt_fix_yaml_format(text: str) -> str:
-    """Attempt to fix common YAML formatting issues."""
-    # This function is not provided in the original file or the code block
-    # It's assumed to exist as it's called in clean_response_text
-    return text
-
-
-def _cleanup_markdown(text: str) -> str:
-    """Clean up common markdown artifacts."""
-    # This function is not provided in the original file or the code block
-    # It's assumed to exist as it's called in clean_response_text
-    return text
-
-
 def clean_response_text(raw_text: str, yaml_terminator_key: str = "suggested_message_es:") -> str:  # noqa: D401
     """Run all cleaning passes on the raw OpenAI response text."""
     cleaned = _strip_markdown_fences(raw_text)


### PR DESCRIPTION
## Summary
- strip unused YAML/markdown cleanup helpers

## Testing
- `pytest -q` *(fails: tests/test_loader_recipe_unique.py::test_all_recipes_loadable, tests/test_loader_recipe_unique.py::test_load_recipe)*