### PR TITLE
Switch load_all_cached_results to sync

### DIFF
--- a/lead_recovery/analysis.py
+++ b/lead_recovery/analysis.py
@@ -115,7 +115,7 @@ async def run_summarization_step(
     
     if use_cache:
         cache = SummaryCache(output_dir)
-        cached_results = await cache.load_all_cached_results() if hasattr(cache, 'load_all_cached_results') else {}
+        cached_results = cache.load_all_cached_results() if hasattr(cache, 'load_all_cached_results') else {}
         conversation_digests = {k: v.get("conversation_digest", "") for k, v in cached_results.items()}
     
     # Log all skip flags for debugging

--- a/lead_recovery/cache.py
+++ b/lead_recovery/cache.py
@@ -591,7 +591,7 @@ class SummaryCache:
         finally:
             conn.close()
             
-    async def load_all_cached_results(self) -> Dict[str, Dict[str, Any]]:
+    def load_all_cached_results(self) -> Dict[str, Dict[str, Any]]:
         """Load all cached results for a specific model.
         
         Returns:


### PR DESCRIPTION
## Summary
- make `load_all_cached_results` synchronous
- adjust `run_summarization_step` to call sync method
- add missing `leads.csv` placeholder for marzo_cohorts_live recipe

## Testing
- `pytest -q`