### PR TITLE
Add template plist and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,4 +166,5 @@ legacy/
 mock_conversations/
 *.log
 *.marker gcp_service_account_key.json
+dashboard_service.plist
 **/leads.csv

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ For more detailed information, refer to the following documentation:
 * [Recipe Creation Guide](RECIPE_CREATION_GUIDE.md) - How to create and configure recipes
 * [PROMPTING_AND_YAML_GUIDE.md](PROMPTING_AND_YAML_GUIDE.md) - Guide to LLM prompting and configuration
 * [Codebase Maintenance](documentation/codebase_maintenance.md) - Guide for maintaining and cleaning up the codebase
+* [Dashboard Service Setup](documentation/dashboard_service_setup.md) - Configure the macOS launch agent
 
 ## Debugging Insights (Key Learnings)
 

--- a/dashboard_service.plist
+++ b/dashboard_service.plist
@@ -8,22 +8,24 @@
     <array>
         <string>/bin/bash</string>
         <string>-c</string>
-        <string>cd /Users/isaacentebi/Desktop/lead_recovery_project && source .env && /Users/isaacentebi/Desktop/lead_recovery_project/fresh_env/bin/streamlit run dashboard/app.py --server.address=0.0.0.0 --server.port=8501</string>
+        <string>cd "$PROJECT_DIR" && source .env && "$PROJECT_DIR"/fresh_env/bin/streamlit run dashboard/app.py --server.address=0.0.0.0 --server.port=8501</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
     <key>WorkingDirectory</key>
-    <string>/Users/isaacentebi/Desktop/lead_recovery_project</string>
+    <string>/path/to/lead_recovery_project</string>
     <key>StandardOutPath</key>
-    <string>/Users/isaacentebi/Desktop/lead_recovery_project/dashboard_log.out</string>
+    <string>/path/to/lead_recovery_project/dashboard_log.out</string>
     <key>StandardErrorPath</key>
-    <string>/Users/isaacentebi/Desktop/lead_recovery_project/dashboard_log.err</string>
+    <string>/path/to/lead_recovery_project/dashboard_log.err</string>
     <key>EnvironmentVariables</key>
     <dict>
+        <key>PROJECT_DIR</key>
+        <string>/path/to/lead_recovery_project</string>
         <key>PATH</key>
-        <string>/Users/isaacentebi/Desktop/lead_recovery_project/fresh_env/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>$PROJECT_DIR/fresh_env/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     </dict>
 </dict>
 </plist> 

--- a/documentation/dashboard_service_setup.md
+++ b/documentation/dashboard_service_setup.md
@@ -1,0 +1,14 @@
+# Dashboard Service Setup
+
+This project includes a `dashboard_service.plist` example for running the Streamlit dashboard on macOS using `launchd`.
+
+1. **Set `PROJECT_DIR`**: Replace `/path/to/lead_recovery_project` in the plist with the absolute path to your local clone. The plist defines a `PROJECT_DIR` environment variable that is used throughout the file.
+2. **Update Working Directory and Logs**: Ensure the `WorkingDirectory`, `StandardOutPath`, and `StandardErrorPath` values all point to your project directory.
+3. **Load the service**:
+   ```bash
+   launchctl load ~/Library/LaunchAgents/dashboard_service.plist
+   ```
+   After editing, reload with `launchctl unload` and `launchctl load`.
+
+If you do not want to track your personalized plist file in version control, it is ignored via `.gitignore`.
+


### PR DESCRIPTION
## Summary
- make dashboard_service.plist use `$PROJECT_DIR` and placeholder paths
- ignore dashboard_service.plist in git
- document dashboard service setup for launchd on macOS

## Testing
- `pre-commit run --files dashboard_service.plist .gitignore documentation/dashboard_service_setup.md README.md` *(fails: unable to access github)*
- `pytest -q`