### PR TITLE
Remove legacy cleanup step

### DIFF
--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -45,8 +45,8 @@ These phases have successfully:
 - Provided templates and examples for different recipe types
 
 #### 5. Recipe Migration
-- Created a `legacy/recipes` directory for deprecated recipes
-- Moved inactive recipes to the legacy directory
+- Created a `legacy/recipes` directory for deprecated recipes (kept for reference; not removed by `cleanup.sh`)
+- Moved inactive recipes to this directory
 - Successfully migrated all active recipes to the new schema:
   - `simulation_to_handoff`
   - `fede_abril_preperfilamiento`

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -13,22 +13,14 @@ rm -v debug_output.log debug_recipe.log skip_test.log 2>/dev/null
 # 3. Clean __pycache__ directories
 find . -type d -name "__pycache__" -exec rm -rf {} +
 
-# 4. Remove the legacy directory if it's not needed
-echo "The 'legacy' directory contains old recipe versions."
-read -p "Remove the legacy directory? (y/n): " remove_legacy
-if [ "$remove_legacy" == "y" ]; then
-  rm -rf legacy
-  echo "Legacy directory removed."
-fi
-
-# 5. Clean test output directory
+# 4. Clean test output directory
 read -p "Remove test_output_run directory? (y/n): " remove_test
 if [ "$remove_test" == "y" ]; then
   rm -rf test_output_run
   echo "test_output_run directory removed."
 fi
 
-# 6. Optional: Clean old output runs
+# 5. Optional: Clean old output runs
 read -p "Remove old output runs (keeping the latest for each recipe)? (y/n): " remove_old_outputs
 if [ "$remove_old_outputs" == "y" ]; then
   # For each recipe directory in output_run
@@ -50,10 +42,10 @@ if [ "$remove_old_outputs" == "y" ]; then
   done
 fi
 
-# 7. Cleanup old log files in root (older than 14 days)
+# 6. Cleanup old log files in root (older than 14 days)
 read -p "Remove log files older than 14 days? (y/n): " remove_old_logs
 if [ "$remove_old_logs" == "y" ]; then
   find . -maxdepth 1 -name "*.log" -type f -mtime +14 -delete -print
 fi
 
-echo "Cleanup completed!" 
+echo "Cleanup completed!"

--- a/documentation/codebase_maintenance.md
+++ b/documentation/codebase_maintenance.md
@@ -77,7 +77,7 @@ The following components are no longer used or have been replaced:
 
 2. **Legacy Directory**
    - The `legacy/` directory contains old recipe versions that are no longer maintained.
-   - This can be safely deleted if those recipes are no longer needed.
+   - It is not removed automatically by `cleanup.sh`. Delete it manually if the recipes are no longer needed.
 
 3. **Test Output Directory**
    - `test_output_run/` is used only for testing and can be deleted.


### PR DESCRIPTION
## Summary
- drop legacy directory prompt from `cleanup.sh`
- update maintenance docs that legacy directory is not auto-removed
- note legacy folder retention in project summary

## Testing
- `pytest -q`