### PR TITLE
Handle None max workers

### DIFF
--- a/documentation/execution_guide.md
+++ b/documentation/execution_guide.md
@@ -35,7 +35,7 @@ python -m lead_recovery.cli.main run --recipe simulation_to_handoff
 | `--skip-redshift / --no-skip-redshift` | FLAG | `--no-skip-redshift` | Skip fetching leads from Redshift |
 | `--skip-bigquery / --no-skip-bigquery` | FLAG | `--no-skip-bigquery` | Skip fetching conversations from BigQuery |
 | `--skip-summarize / --no-skip-summarize` | FLAG | `--skip-summarize` | Skip summarizing conversations with LLM |
-| `--max-workers` | INTEGER | None | Max concurrent workers for OpenAI calls |
+| `--max-workers` | INTEGER | None | Max concurrent workers for OpenAI calls. Values `None` or `<=0` default to `min(32, max(4, cpu_count))` |
 | `--output-dir` | TEXT | None | Override base output directory |
 | `--use-cached-redshift / --no-use-cached-redshift` | FLAG | `--use-cached-redshift` | Use cached Redshift data if available |
 | `--use-cache / --no-cache` | FLAG | `--use-cache` | Use summarization cache if available |

--- a/lead_recovery/analysis.py
+++ b/lead_recovery/analysis.py
@@ -88,7 +88,7 @@ async def _process_conversations(
     convos_df: pd.DataFrame,
     processor_runner: ProcessorRunner | None,
     prompt_template_path: Path | None,
-    max_workers: int,
+    max_workers: int | None,
     use_cache: bool,
     cached_results: dict[str, dict],
     conversation_digests: dict[str, str],
@@ -110,7 +110,7 @@ async def _process_conversations(
     )
     validator = YamlValidator(meta_config=meta_config)
 
-    if max_workers is None:
+    if max_workers is None or max_workers <= 0:
         max_workers = min(32, max(4, os.cpu_count() or 4))
     logger.info("Using max_workers=%s for concurrent processing", max_workers)
 
@@ -355,7 +355,7 @@ async def run_summarization_step(
             convos_df,
             processor_runner,
             prompt_template_path,
-            max_workers if max_workers is not None else 0,
+            max_workers,
             use_cache,
             cached_results,
             conversation_digests,

--- a/tests/test_analysis_workers.py
+++ b/tests/test_analysis_workers.py
@@ -1,0 +1,58 @@
+import logging
+
+import pandas as pd
+import pytest
+
+from lead_recovery import analysis
+
+
+class DummySummarizer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def summarize(self, conv_df, temporal_flags=None):
+        return {"summary": "ok"}
+
+
+class DummyValidator:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def fix_yaml(self, data, temporal_flags=None):
+        return data
+
+
+@pytest.mark.asyncio
+async def test_process_conversations_default_workers(monkeypatch, caplog):
+    convos_df = pd.DataFrame(
+        {
+            "creation_time": ["2024-01-01T00:00:00", "2024-01-01T00:01:00"],
+            "msg_from": ["user", "bot"],
+            "message": ["hi", "hello"],
+            analysis.CLEANED_PHONE_COLUMN_NAME: ["1234567890", "1234567890"],
+        }
+    )
+
+    monkeypatch.setattr(analysis, "ConversationSummarizer", DummySummarizer)
+    monkeypatch.setattr(analysis, "YamlValidator", DummyValidator)
+
+    caplog.set_level(logging.INFO)
+
+    summaries, errors = await analysis._process_conversations(
+        convos_df,
+        None,
+        None,
+        None,
+        False,
+        {},
+        {},
+        None,
+        None,
+    )
+
+    assert not errors
+    worker_logs = [r for r in caplog.records if "Using max_workers" in r.getMessage()]
+    assert worker_logs
+    msg = worker_logs[0].getMessage()
+    count = int(msg.split("=")[1].split()[0])
+    assert count > 0


### PR DESCRIPTION
## Summary
- allow `None` to be passed as `max_workers`
- handle values `<=0` when calculating worker pool size
- document defaulting behaviour for `--max-workers`
- test that default workers are greater than zero
- fix import ordering

## Testing
- `ruff check . --output-format=github`
- `pytest -q`
