### PR TITLE
Add environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,17 @@ You can override output columns at runtime with CLI flags:
    cd lead_recovery_project
    ```
 
-2. **Create and activate a virtual environment:**
+2. **Run the setup script to create the virtual environment and install dependencies:**
    ```bash
-   python -m venv fresh_env
-   source fresh_env/bin/activate  # On Windows: fresh_env\Scripts\activate
+   ./setup_env.sh
    ```
 
-3. **Install dependencies (choose one method):**
+   This script creates a `fresh_env` directory and installs everything from
+   `requirements.txt`, `requirements-dev.txt`, and the package itself in
+   editable mode. If you prefer to do this manually, create and activate the
+   environment then install dependencies as shown below.
+
+3. **Manual dependency installation (optional):**
    
    Using pip:
    ```bash

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Setup script for the lead_recovery project
+# Creates a virtual environment and installs all dependencies.
+
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$PROJECT_DIR"
+
+VENV_DIR="fresh_env"
+
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR"/bin/activate
+
+python -m pip install --upgrade pip
+
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt
+fi
+
+if [ -f requirements-dev.txt ]; then
+    pip install -r requirements-dev.txt
+fi
+
+pip install -e .
+
+echo "Virtual environment created at '$VENV_DIR'. Activate it with 'source $VENV_DIR/bin/activate'."


### PR DESCRIPTION
## Summary
- add `setup_env.sh` for creating a `fresh_env` virtual environment
- document using the script in the setup instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68519d125578832285d417c36b783307