### PR TITLE
Ignore sensitive leads.csv files in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,5 @@ jobs:
           pip install -e .
       - name: Lint with ruff
         run: ruff check . --output-format=github
-      - name: Create placeholder leads.csv files for tests
-        run: |
-          touch recipes/marzo_cohorts_live/leads.csv
-          touch recipes/fede_abril_preperfilamiento/leads.csv
-          touch recipes/marzo_cohorts/leads.csv
-          touch recipes/top_up_may/leads.csv
       - name: Test with pytest
         run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ cython_debug/
 
 # Project specific
 recipes/*/output_run/
+recipes/*/leads.csv
 legacy/
 mock_conversations/
 *.log

--- a/README.md
+++ b/README.md
@@ -178,15 +178,10 @@ You can override output columns at runtime with CLI flags:
 
 ## Running Tests
 
-Install the development dependencies (includes `pytest-asyncio`) and ensure
-placeholder CSV files exist for recipes before running `pytest`:
+Install the development dependencies (includes `pytest-asyncio`) and run tests:
 
 ```bash
 pip install -r requirements-dev.txt
-touch recipes/marzo_cohorts_live/leads.csv
-touch recipes/fede_abril_preperfilamiento/leads.csv
-touch recipes/marzo_cohorts/leads.csv
-touch recipes/top_up_may/leads.csv
 pytest -q
 ```
 

--- a/tests/test_loader_recipe_unique.py
+++ b/tests/test_loader_recipe_unique.py
@@ -40,8 +40,10 @@ def test_all_recipes_loadable():
             assert Path(di.redshift_config.sql_file).exists(), f"{di.redshift_config.sql_file} missing"
         if di.bigquery_config and di.bigquery_config.sql_file:
             assert Path(di.bigquery_config.sql_file).exists(), f"{di.bigquery_config.sql_file} missing"
+        # ``leads.csv`` files contain sensitive data and are typically excluded
+        # from version control, so skip existence checks for them.
         if di.csv_config and di.csv_config.csv_file:
-            assert Path(di.csv_config.csv_file).exists(), f"{di.csv_config.csv_file} missing"
+            assert isinstance(di.csv_config.csv_file, str)
         if di.conversation_sql_file_redshift:
             assert Path(di.conversation_sql_file_redshift).exists(), f"{di.conversation_sql_file_redshift} missing"
         if di.conversation_sql_file_bigquery:
@@ -78,6 +80,6 @@ def test_load_recipe():
     if di.bigquery_config and di.bigquery_config.sql_file:
         assert Path(di.bigquery_config.sql_file).exists()
     if di.csv_config and di.csv_config.csv_file:
-        assert Path(di.csv_config.csv_file).exists()
+        assert isinstance(di.csv_config.csv_file, str)
     if meta.llm_config and meta.llm_config.prompt_file:
         assert Path(meta.llm_config.prompt_file).exists()


### PR DESCRIPTION
## Summary
- stop tracking leads.csv files and add them to `.gitignore`
- remove placeholder creation step from CI
- relax loader tests so they don't require `leads.csv`
- update README test instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851a3c794cc8322853037ad8fa518d9